### PR TITLE
Remove log4j.properties from the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,5 +37,15 @@
         </dependency>
     </dependencies>
 
+    <build>
+         <resources>
+             <resource>
+                 <directory>src/main/resources</directory>
+                 <excludes>
+                     <exclude>log4j.properties</exclude>
+                 </excludes>
+             </resource>
+         </resources>
+     </build>
 
 </project>


### PR DESCRIPTION
This removes the ability for users of the jar to configure their own logging, so it should probably be excluded from the final jar.